### PR TITLE
Fix object name.

### DIFF
--- a/wefunk_dl
+++ b/wefunk_dl
@@ -57,7 +57,7 @@ def download_media(url, save_as=False):
     media_info['size'] = file_size
     media_info['url'] = url
     media_info['save_as'] = save_as
-    media_info['http'] = u.getcode()
+    media_info['http'] = request_handler.getcode()
     return media_info
 
 

--- a/wefunk_dl
+++ b/wefunk_dl
@@ -92,7 +92,7 @@ class WeFunkShow():
         """ Get the available informations from the show on the wefunk website
         """
         logger.debug('Getting URL {}'.format(self.url))
-        html = geturl(self.url)
+        html = geturl(self.url).decode('utf-8')
         parser = ShowParser()
         parser.feed(html)
         self.filename = parser.show_name + '.mp3'


### PR DESCRIPTION
There are 2 commits:

1/ 8ecfc11 fixes a minor bug that spits an error after downloading a show:
```python
Traceback (most recent call last):
  File "./wefunk_dl", line 164, in <module>
    download_result = download_media(media_location, show.filename)
  File "./wefunk_dl", line 60, in download_media
    media_info['http'] = u.getcode()
NameError: global name 'u' is not defined
```
The file was probably not fully saved when latest commit happened.

2/ 615b57f fixes a unicode problem that only happens on certain shows (ex 789):
```python
Traceback (most recent call last):
  File "./wefunk_dl", line 158, in <module>
    show = WeFunkShow(show_id)
  File "./wefunk_dl", line 89, in __init__
    self.fetch_data()
  File "./wefunk_dl", line 97, in fetch_data
    parser.feed(html)
  File "/usr/lib/python2.7/HTMLParser.py", line 117, in feed
    self.goahead(0)
  File "/usr/lib/python2.7/HTMLParser.py", line 161, in goahead
    k = self.parse_starttag(i)
  File "/usr/lib/python2.7/HTMLParser.py", line 308, in parse_starttag
    attrvalue = self.unescape(attrvalue)
  File "/usr/lib/python2.7/HTMLParser.py", line 475, in unescape
    return re.sub(r"&(#?[xX]?(?:[0-9a-fA-F]+|\w{1,8}));", replaceEntities, s)
  File "/usr/lib/python2.7/re.py", line 151, in sub
    return _compile(pattern, flags).sub(repl, string, count)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 93: ordinal not in range(128)
```