### PR TITLE
Make the download URL search case insensitive.

### DIFF
--- a/wefunk_dl
+++ b/wefunk_dl
@@ -75,7 +75,7 @@ class ShowParser(HTMLParser): # pylint: disable=R0904
         if tag == 'a':
             if 'href' in dict(attrs):
                 link = dict(attrs)['href']
-                if link.startswith('/playlaunch/WeFunk_Show'):
+                if link.lower().startswith('/playlaunch/wefunk_show'):
                     self.show_name = link.replace('/playlaunch/', '')
 
 


### PR DESCRIPTION
The latest URLs seem to have WEFUNK completely capitalized, such as here:
`/playlaunch/WEFUNK_Show`

VS previously:
`/playlaunch/WeFunk_Show`

This commit allows ignoring the case, fixing a blocking problem but staying backwards compatible.
Hopefully it will be a good enough fix for you ;)